### PR TITLE
feat: リリースワークフローとインストールスクリプト

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          dir="shx-${tag}-${{ matrix.target }}"
+          mkdir "$dir"
+          cp "target/${{ matrix.target }}/release/shx" "$dir/"
+          cp "target/${{ matrix.target }}/release/bashx" "$dir/"
+          cp README.md LICENSE "$dir/"
+          tar czf "${dir}.tar.gz" "$dir"
+          echo "ASSET=${dir}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          files=$(find artifacts -name '*.tar.gz' -type f)
+          gh release create "$tag" $files \
+            --title "$tag" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -87,7 +87,15 @@ greet "$name"
 
 ## Install
 
-From source (requires Rust toolchain):
+ワンライナー:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hrtk91/shx/master/install.sh | sh
+```
+
+[GitHub Releases](https://github.com/hrtk91/shx/releases) からバイナリを直接ダウンロードもできます。
+
+ソースからビルド (Rust toolchain が必要):
 
 ```
 cargo install --path .

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# shx installer — GitHub Releases からバイナリをダウンロードしてインストール
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/hrtk91/shx/master/install.sh | sh
+#
+# Options (環境変数):
+#   SHX_INSTALL_DIR  インストール先 (default: /usr/local/bin)
+#   SHX_VERSION      バージョン指定 (default: latest)
+
+set -eu
+
+REPO="hrtk91/shx"
+INSTALL_DIR="${SHX_INSTALL_DIR:-/usr/local/bin}"
+
+# --- OS / Arch 検出 ---
+detect_target() {
+  os=$(uname -s)
+  arch=$(uname -m)
+
+  case "$os" in
+    Linux)
+      # musl 版を優先（静的リンクで互換性が高い）
+      case "$arch" in
+        x86_64)  echo "x86_64-unknown-linux-musl" ;;
+        aarch64) echo "aarch64-unknown-linux-gnu" ;;
+        *)       echo "unsupported: $os/$arch" >&2; exit 1 ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64)  echo "x86_64-apple-darwin" ;;
+        arm64)   echo "aarch64-apple-darwin" ;;
+        *)       echo "unsupported: $os/$arch" >&2; exit 1 ;;
+      esac
+      ;;
+    *)
+      echo "unsupported OS: $os" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# --- バージョン取得 ---
+get_version() {
+  if [ -n "${SHX_VERSION:-}" ]; then
+    echo "$SHX_VERSION"
+    return
+  fi
+  # GitHub API で最新タグを取得
+  curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' \
+    | head -1 \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/'
+}
+
+main() {
+  target=$(detect_target)
+  version=$(get_version)
+  archive="shx-${version}-${target}.tar.gz"
+  url="https://github.com/$REPO/releases/download/${version}/${archive}"
+
+  echo "shx ${version} (${target}) をインストールします..."
+
+  tmpdir=$(mktemp -d)
+  trap "rm -rf $tmpdir" EXIT
+
+  echo "ダウンロード中: $url"
+  curl -fsSL "$url" -o "$tmpdir/$archive"
+
+  echo "展開中..."
+  tar xzf "$tmpdir/$archive" -C "$tmpdir"
+
+  echo "インストール先: $INSTALL_DIR"
+  install -m 755 "$tmpdir/shx-${version}-${target}/shx" "$INSTALL_DIR/shx"
+  install -m 755 "$tmpdir/shx-${version}-${target}/bashx" "$INSTALL_DIR/bashx"
+
+  echo ""
+  echo "インストール完了!"
+  echo "  shx:   $(command -v shx || echo "$INSTALL_DIR/shx")"
+  echo "  bashx: $(command -v bashx || echo "$INSTALL_DIR/bashx")"
+  echo ""
+  "$INSTALL_DIR/shx" --version
+}
+
+main


### PR DESCRIPTION
## 概要
- GitHub Actions でタグ push 時にクロスビルド → Releases 作成
- `curl -fsSL .../install.sh | sh` でインストール可能に
- 対応プラットフォーム: Linux (x86_64, aarch64, musl), macOS (x86_64, aarch64)

## 使い方
```sh
# リリース作成
git tag v0.1.0
git push origin v0.1.0

# ユーザーのインストール
curl -fsSL https://raw.githubusercontent.com/hrtk91/shx/master/install.sh | sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)